### PR TITLE
Fix crash in initial install in debian12

### DIFF
--- a/install-mariadb.sh
+++ b/install-mariadb.sh
@@ -641,7 +641,7 @@ key_buffer              = 16M
 
 EOF
 
-
+mytest service mysql start > /dev/null
 
 case "$VERSION" in
     "11.4")      ;;


### PR DESCRIPTION
Hello,

I encountered an issue during the initial installation of PMAcontrol on a Debian 12.12 VM.
In the install-mariadb.sh file, line 564, the mysql command cannot be executed because the mariadb server is still down at that point.
Startup is not automatic.

I suggest this small fix that helped me.

Have a nice day.